### PR TITLE
Alternate approach using intersection observer

### DIFF
--- a/Data/WeatherForecast.cs
+++ b/Data/WeatherForecast.cs
@@ -4,6 +4,8 @@ namespace BlazorApp18.Data
 {
     public class WeatherForecast
     {
+        public int Index { get; set; }
+
         public DateTime Date { get; set; }
 
         public int TemperatureC { get; set; }

--- a/Data/WeatherForecastService.cs
+++ b/Data/WeatherForecastService.cs
@@ -16,6 +16,7 @@ namespace BlazorApp18.Data
             var rng = new Random();
             return Task.FromResult(Enumerable.Range(1, 1000).Select(index => new WeatherForecast
             {
+                Index = index,
                 Date = startDate.AddDays(index),
                 TemperatureC = rng.Next(-20, 55),
                 Summary = Summaries[rng.Next(Summaries.Length)]

--- a/Pages/FetchData.razor
+++ b/Pages/FetchData.razor
@@ -17,6 +17,7 @@ else
     <div style="height:300px; overflow-y: auto;">
         <Virtualize ItemHeight="25" Items="@forecasts">
             <tr @key="@context.GetHashCode()" style="display: table; table-layout: fixed; width: 100%;">
+                <td>@context.Index</td>
                 <td>@context.Date.ToShortDateString()</td>
                 <td>@context.TemperatureC</td>
                 <td>@context.TemperatureF</td>
@@ -30,6 +31,7 @@ else
         <table>
             <thead class="sticky">
                 <tr>
+                    <th>Index</th>
                     <th>Date</th>
                     <th>Temperature (C)</th>
                     <th>Temperature (F)</th>
@@ -59,6 +61,7 @@ else
 
             <Virtualize TagName="tbody" ItemHeight="25" Items="@forecasts">
                 <tr @key="@context.GetHashCode()">
+                    <td>@context.Index</td>
                     <td>@context.Date.ToShortDateString()</td>
                     <td>@context.TemperatureC</td>
                     <td>@context.TemperatureF</td>

--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -2,6 +2,17 @@
 
 <h1>Hello, world!</h1>
 
-Welcome to your new app.
+<div style="background-color: #eee; height: 500px; overflow-y: auto">
+    <VirtualList Items="@Items" ItemHeight="100">
+        <div @key="@context" style="height: 100px; background-color: rgb(@((context % 2) * 255), @((1-(context % 2)) * 255), 255);">Item @context</div>
+    </VirtualList>
+    <VirtualList Items="@Items" ItemHeight="100">
+        <div @key="@context" style="height: 100px; background-color: rgb(0, @((context % 2) * 255), @((1-(context % 2)) * 255));">Item @context</div>
+    </VirtualList>
+</div>
 
 
+@code {
+    Random rng = new Random();
+    ICollection<int> Items = Enumerable.Range(1, 1000).ToList();
+}

--- a/Shared/VirtualList.razor
+++ b/Shared/VirtualList.razor
@@ -1,0 +1,120 @@
+﻿@typeparam TItem
+@inject IJSRuntime JS
+<div @key="@("spacerBefore")" @ref="spacerBefore" data-rendercount="@(++renderCount)" class="spacer" style="height: @(itemsToSkipBefore * ItemHeight)px"></div>@{
+    foreach (var item in Items.Skip(itemsToSkipBefore).Take(itemsToShow))
+    {
+        ChildContent(item)(__builder);
+    }
+}
+<div @key="@("spacerAfter")" @ref="spacerAfter" class="spacer" style="height: @(ItemsToSkipAfter * ItemHeight)px"></div>
+<style type="text/css">
+    .spacer {
+        background-color: orange;
+    }
+</style>
+<script suppress-error="BL9992">
+    function findClosestScrollContainer(elem) {
+        while (elem = elem.parentElement) {
+            const style = getComputedStyle(elem);
+            if (style.overflowY !== 'visible') {
+                return elem;
+            }
+        }
+        throw new Error('No scrollable ancestor found for element');
+    }
+
+    window.VirtualList = {
+        init: function (component, spacerBefore, spacerAfter) {
+            const scrollContainer = findClosestScrollContainer(spacerBefore);
+            const rootMargin = 50;
+            const intersectionObserver = new IntersectionObserver(onIntersectionRectChanged, {
+                root: scrollContainer, rootMargin: `${rootMargin}px`
+            });
+            intersectionObserver.observe(spacerBefore);
+            intersectionObserver.observe(spacerAfter);
+
+            // After each render, refresh the info about intersections
+            const mutationObserver = new MutationObserver(mutations => {
+                intersectionObserver.unobserve(spacerBefore);
+                intersectionObserver.unobserve(spacerAfter);
+                intersectionObserver.observe(spacerBefore);
+                intersectionObserver.observe(spacerAfter);
+            });
+            mutationObserver.observe(spacerBefore, { attributes: true })
+
+            function onIntersectionRectChanged(entries, observer) {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting && entry.target.offsetHeight > 0) {
+                        requestIdleCallback(() => {
+                            const spacerType = entry.target === spacerBefore ? 'before' : 'after';
+                            const visibleRect = {
+                                top: entry.intersectionRect.top - entry.boundingClientRect.top,
+                                left: entry.intersectionRect.left - entry.boundingClientRect.left,
+                                width: entry.intersectionRect.width,
+                                height: entry.intersectionRect.height
+                            };
+                            component.invokeMethodAsync('OnSpacerVisible', spacerType, visibleRect, scrollContainer.offsetHeight + 2 * rootMargin, spacerBefore.offsetHeight, spacerAfter.offsetHeight);
+                        });
+                    }
+                });
+            }
+        }
+    };
+</script>
+@code {
+    [Parameter] public ICollection<TItem> Items { get; set; }
+
+    [Parameter] public double ItemHeight { get; set; }
+
+    [Parameter] public RenderFragment<TItem> ChildContent { get; set; }
+
+    DotNetObjectReference<VirtualList<TItem>> selfReference;
+    ElementReference spacerBefore;
+    ElementReference spacerAfter;
+    long renderCount;
+    int itemsToSkipBefore;
+    int itemsToShow;
+    int ItemsToSkipAfter => Items.Count() - itemsToSkipBefore - itemsToShow;
+
+    protected override async Task OnAfterRenderAsync(bool first)
+    {
+        if (first)
+        {
+            selfReference = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("VirtualList.init", selfReference, spacerBefore, spacerAfter);
+        }
+    }
+
+    [JSInvokable]
+    public void OnSpacerVisible(string spacerType, Rect visibleRect, double containerHeight, double spacerBeforeHeight, double spacerAfterHeight)
+    {
+        // Reset to match values corresponding to this event
+        itemsToSkipBefore = (int)Math.Round(spacerBeforeHeight / ItemHeight);
+        itemsToShow = Items.Count() - itemsToSkipBefore - (int)Math.Round(spacerAfterHeight / ItemHeight);
+
+        if (spacerType == "before" && itemsToSkipBefore > 0)
+        {
+            var visibleTop = visibleRect.Top;
+            var firstVisibleItemIndex = (int)Math.Floor(visibleTop / ItemHeight);
+            itemsToShow = (int)Math.Ceiling(containerHeight / ItemHeight) + 1;
+            itemsToSkipBefore = Math.Max(0, firstVisibleItemIndex);
+            StateHasChanged();
+        }
+        else if (spacerType == "after" && ItemsToSkipAfter > 0)
+        {
+            var visibleBottom = visibleRect.Top + visibleRect.Height;
+            var lastVisibleItemIndex = itemsToSkipBefore + itemsToShow + (int)Math.Ceiling(visibleBottom / ItemHeight);
+            itemsToShow = (int)Math.Ceiling(containerHeight / ItemHeight) + 1;
+            itemsToSkipBefore = Math.Max(0, lastVisibleItemIndex - itemsToShow);
+            StateHasChanged();
+        }
+    }
+
+    public class Rect
+    {
+        public double Top { get; set; }
+        public double Left { get; set; }
+        public double Width { get; set; }
+        public double Height { get; set; }
+    }
+}


### PR DESCRIPTION
I know you might not be planning to go any further with this soon, so I'm only submitting this to keep track of some thoughts and ideas. I spent a bit more time messing with this last night based on the idea that we should avoid using `onscroll` events.

The approach here is to add spacer elements before/after the displayed items to expand the scroll range, and use `IntersectionObserver` to get notified when they would come into the viewport. Then we update the visible range.

It has these advantages:

 * No use of `onscroll`, so we no longer have to make JS->.NET calls on every subpixel of scrolling. Instead we just make a single JS->.NET call when the spacer elements are coming into view. This will perform vastly better, especially on Blazor Server.
 * No artificial extra elements need to be added into the DOM hierarchy, so this no longer interferes at all whether you're doing nested `<div>`s or `<table>`, `<ul>`, or anything else.
 * Calculations are simpler. It works to stack multiple virtualized lists next to each other in the same scroll container.

I haven't tried to make everything work though. For example currently it requires you to put the `<VirtualList>` inside a scrollable element. Ideally it should accept the `documentElement` as being the scroll container too if there's nothing else, so you can virtualize when doing regular top-level page scrolling.

Also for development convenience I smushed everything into one `.razor` file including the JS. That's not how we'd ship something like this :)